### PR TITLE
Added aliases for Sheet's buttons enabled properties

### DIFF
--- a/src/meego/Sheet.qml
+++ b/src/meego/Sheet.qml
@@ -59,6 +59,9 @@ Item {
     property alias acceptButton: acceptButton
     property alias rejectButton: rejectButton
 
+    property alias acceptButtonEnabled: acceptButton.enabled
+    property alias rejectButtonEnabled: rejectButton.enabled
+
     signal accepted
     signal rejected
 


### PR DESCRIPTION
Added aliases for disabling Sheet's buttons as discussed here:

https://github.com/nemomobile/qmlcontacts/pull/2

Signed-off-by: Tero Siironen tero.siironen@gmail.com
