### PR TITLE
Hide the status bar if there is no valid pixmap to be drawn

### DIFF
--- a/src/meego/StatusBar.qml
+++ b/src/meego/StatusBar.qml
@@ -50,7 +50,7 @@ StatusBarInternal {
     property bool __completed: false
 
     states: State {
-        name: "hide"; when: showStatusBar==false
+        name: "hide"; when: showStatusBar==false || statusBar.hasPixmap==false
         PropertyChanges { target: statusBar; anchors.topMargin: -statusBar.height; visible: false}
     }
 

--- a/src/meego/mdeclarativestatusbar.h
+++ b/src/meego/mdeclarativestatusbar.h
@@ -63,6 +63,7 @@ class MDeclarativeStatusBar : public QDeclarativeItem
 {
     Q_OBJECT
     Q_PROPERTY(MDeclarativeScreen::Orientation orientation READ orientation WRITE setOrientation NOTIFY orientationChanged)
+    Q_PROPERTY(bool hasPixmap READ hasPixmap NOTIFY hasPixmapChanged)
 
 public:
     MDeclarativeStatusBar(QDeclarativeItem *parent = 0);
@@ -72,6 +73,8 @@ public:
     MDeclarativeScreen::Orientation orientation() const;
 
     virtual void paint(QPainter *, const QStyleOptionGraphicsItem *, QWidget *);
+
+    bool hasPixmap() const;
 
 public Q_SLOTS:
     void updateXdamageEventSubscription();
@@ -113,6 +116,7 @@ private:
 
 Q_SIGNALS:
     void orientationChanged();
+    void hasPixmapChanged();
 
 private Q_SLOTS:
     void disablePressedFeedback();


### PR DESCRIPTION
Adds a hasPixmap property to the MDeclarativeStatusBar which can be used to hide the status bar when there is no valid pixmap.
There is no need to request the pixmap on every paint() - there's a D-Bus service watcher for the pixmap service in place so querying the pixmap when the service provider changes is enough.
