### PR TITLE
Remove javascript font family variables and bindings.

### DIFF
--- a/doc/src/meego/qt-components-buttonstyle.qdoc
+++ b/doc/src/meego/qt-components-buttonstyle.qdoc
@@ -71,7 +71,7 @@
 /*!
     \qmlproperty string ButtonStyle::fontFamily
 
-    Property default value is \c UI.FONT_FAMILY.
+    Property default value is \c UiConstants.DefaultFontFamily.
 
     Defines the font family for the button.
 */

--- a/doc/src/meego/qt-components-contextmenustyle.qdoc
+++ b/doc/src/meego/qt-components-contextmenustyle.qdoc
@@ -62,7 +62,7 @@
 /*!
     \qmlproperty string ContextMenuStyle::titleFontFamily
 
-    Property default value is \c UI.FONT_FAMILY
+    Property default value is \c UiConstants.DefaultFontFamily.
 
     Font family.
 */

--- a/doc/src/meego/qt-components-labelstyle.qdoc
+++ b/doc/src/meego/qt-components-labelstyle.qdoc
@@ -70,7 +70,7 @@
 /*!
     \qmlproperty string LabelStyle::fontFamily
 
-    Property default value is \c UI.FONT_FAMILY
+    Property default value is \c UiConstants.DefaultFontFamily.
 
     Font family.
 */

--- a/doc/src/meego/qt-components-sliderstyle.qdoc
+++ b/doc/src/meego/qt-components-sliderstyle.qdoc
@@ -75,7 +75,7 @@
 /*!
     \qmlproperty string SliderStyle::fontFamily
 
-    Property default value is \c UI.FONT_FAMILY.
+    Property default value is \c UiConstants.DefaultFontFamily.
 
     Font family.
 */

--- a/src/meego/UIConstants.js
+++ b/src/meego/UIConstants.js
@@ -40,13 +40,6 @@
 
 .pragma library
 
-var FONT_FAMILY = "Nokia Pure Text";
-var FONT_FAMILY_LIGHT = "Nokia Pure Text Light"
-
-// we use a fallback font when language is set to farsi
-var FONT_FAMILY_FARSI = "Arial"
-var FONT_FAMILY_LIGHT_FARSI = "Arial"
-
 var FONT_DEFAULT_SIZE = 24; // DEPRECATED
 
 var FONT_XLARGE  = 32;

--- a/src/meego/extras/CountBubble.qml
+++ b/src/meego/extras/CountBubble.qml
@@ -40,7 +40,6 @@
 
 import QtQuick 1.1
 import com.nokia.meego 1.0
-import "constants.js" as C
 
 /*
    Class: CountBubble
@@ -77,7 +76,7 @@ ImplicitSizeItem {
         height: parent.height
         y:1
         color: largeSized ? "#FFFFFF" : "black"
-        font.family: C.FONT_FAMILY
+        font.family: UiConstants.DefaultFontFamily
         anchors.horizontalCenter: parent.horizontalCenter
         verticalAlignment: Text.AlignVCenter
         font.pixelSize: largeSized ? 22:18

--- a/src/meego/extras/DatePickerDialog.qml
+++ b/src/meego/extras/DatePickerDialog.qml
@@ -40,7 +40,6 @@
 
 import QtQuick 1.1
 import com.nokia.meego 1.0
-import "constants.js" as C
 import "TumblerIndexHelper.js" as TH
 
 /*
@@ -117,7 +116,7 @@ Dialog {
         text: "Pick Date"
         visible: text.length > 0
         color: theme.selectionColor
-        font { pixelSize: 32; family: C.FONT_FAMILY_BOLD }
+        font { pixelSize: 32; family: UiConstants.DefaultFontFamilyBold }
         elide: Text.ElideRight
     }
     content: Item {

--- a/src/meego/extras/ListDelegate.qml
+++ b/src/meego/extras/ListDelegate.qml
@@ -50,13 +50,13 @@ Item {
 
     property int titleSize: UI.LIST_TILE_SIZE
     property int titleWeight: Font.Bold
-    property string titleFont: (locale && locale.language == "fa") ? UI.FONT_FAMILY_FARSI : UI.FONT_FAMILY
+    property string titleFont: UiConstants.DefaultFontFamily
     property color titleColor: theme.inverted ? UI.LIST_TITLE_COLOR_INVERTED : UI.LIST_TITLE_COLOR
     property color titleColorPressed: theme.inverted ? UI.LIST_TITLE_COLOR_PRESSED_INVERTED : UI.LIST_TITLE_COLOR_PRESSED
 
     property int subtitleSize: UI.LIST_SUBTILE_SIZE
     property int subtitleWeight: Font.Normal
-    property string subtitleFont: (locale && locale.language == "fa") ? UI.FONT_FAMILY_LIGHT_FARSI : UI.FONT_FAMILY_LIGHT
+    property string subtitleFont: UiConstants.DefaultFontFamilyLight
     property color subtitleColor: theme.inverted ? UI.LIST_SUBTITLE_COLOR_INVERTED : UI.LIST_SUBTITLE_COLOR
     property color subtitleColorPressed: theme.inverted ? UI.LIST_SUBTITLE_COLOR_PRESSED_INVERTED : UI.LIST_SUBTITLE_COLOR_PRESSED
 

--- a/src/meego/extras/TimePickerDialog.qml
+++ b/src/meego/extras/TimePickerDialog.qml
@@ -41,7 +41,6 @@
 import QtQuick 1.1
 import com.nokia.meego 1.0
 import com.nokia.extras 1.1
-import "constants.js" as C
 import "TumblerIndexHelper.js" as TH
 
 /*
@@ -132,7 +131,7 @@ Dialog {
         text: "Pick Time"
         visible: text.length > 0
         color: theme.selectionColor
-        font { pixelSize: 32; family: C.FONT_FAMILY_BOLD }
+        font { pixelSize: 32; family: UiConstants.DefaultFontFamilyBold }
         elide: Text.ElideRight
     }
     content: Item {

--- a/src/meego/extras/TumblerTemplate.qml
+++ b/src/meego/extras/TumblerTemplate.qml
@@ -156,7 +156,7 @@ Item {
             elide: Text.ElideRight
             horizontalAlignment: "AlignHCenter"
             color: C.TUMBLER_COLOR_LABEL
-            font { family: C.FONT_FAMILY_LIGHT; pixelSize: C.FONT_LIGHT_SIZE }
+            font { family: UiConstants.DefaultFontFamilyLight; pixelSize: C.FONT_LIGHT_SIZE }
             anchors { fill: parent; margins: C.TUMBLER_MARGIN}
         }
     }

--- a/src/meego/extras/constants.js
+++ b/src/meego/extras/constants.js
@@ -63,15 +63,8 @@ var LIST_SUBTITLE_COLOR_INVERTED = "#C8C8C8"
 var LIST_SUBTITLE_COLOR_PRESSED_INVERTED = "#797979"
 
 /* Font properties */
-var FONT_FAMILY = "Nokia Pure Text";
-var FONT_FAMILY_BOLD = "Nokia Pure Text Bold";
-var FONT_FAMILY_LIGHT = "Nokia Pure Text Light";
 var FONT_DEFAULT_SIZE = 24;
 var FONT_LIGHT_SIZE = 22;
-
-// we use a fallback font when language is set to farsi
-var FONT_FAMILY_FARSI = "Arial"
-var FONT_FAMILY_LIGHT_FARSI = "Arial"
 
 /* TUMBLER properties */
 var TUMBLER_COLOR_TEXT = "#FFFFFF";

--- a/src/meego/plugin.cpp
+++ b/src/meego/plugin.cpp
@@ -166,6 +166,9 @@ public:
         }
 
         QDeclarativePropertyMap *uiConstantsData = new QDeclarativePropertyMap();
+        uiConstantsData->insert("DefaultFontFamily", defaultFontFamily);
+        uiConstantsData->insert("DefaultFontFamilyLight", defaultFontFamilyLight);
+        uiConstantsData->insert("DefaultFontFamilyBold", "Nokia Pure Text Bold");
         uiConstantsData->insert("DefaultMargin", QVariant(16));
         uiConstantsData->insert("ButtonSpacing", QVariant(6));
         uiConstantsData->insert("HeaderDefaultHeightPortrait", QVariant(72));

--- a/src/meego/style/ButtonStyle.qml
+++ b/src/meego/style/ButtonStyle.qml
@@ -43,7 +43,7 @@ import "UIConstants.js" as UI
 
 Style {
     // Font
-    property string fontFamily: __fontFamily()
+    property string fontFamily: UiConstants.DefaultFontFamily
     property int fontPixelSize: UI.FONT_DEFAULT_SIZE
     property int fontCapitalization: Font.MixedCase
     property int fontWeight: Font.Bold

--- a/src/meego/style/ContextMenuStyle.qml
+++ b/src/meego/style/ContextMenuStyle.qml
@@ -42,8 +42,8 @@ import QtQuick 1.1
 import "UIConstants.js" as UI
 
 MenuStyle {
- id: root
- property string titleFontFamily: __fontFamily()
+     id: root
+    property string titleFontFamily: UiConstants.DefaultFontFamily
      property int titleFontPixelSize: UI.FONT_SMALL
      property int titleFontCapitalization: Font.MixedCase
      property color titleTextColor: "white"

--- a/src/meego/style/EditBubbleButtonStyle.qml
+++ b/src/meego/style/EditBubbleButtonStyle.qml
@@ -43,7 +43,7 @@ import "UIConstants.js" as UI
 
 Style {
     // Font
-    property string fontFamily: __fontFamily()
+    property string fontFamily: UiConstants.DefaultFontFamily
     property int fontPixelSize: UI.FONT_DEFAULT_SIZE
     property int fontCapitalization: Font.MixedCase
     property int fontWeight: Font.Normal

--- a/src/meego/style/LabelStyle.qml
+++ b/src/meego/style/LabelStyle.qml
@@ -48,6 +48,6 @@ Style {
     property color selectionColor: theme.selectionColor
 
     // Font
-    property string fontFamily: __fontFamily()
+    property string fontFamily: UiConstants.DefaultFontFamily
     property int fontPixelSize: UI.FONT_DEFAULT_SIZE
 }

--- a/src/meego/style/MenuItemStyle.qml
+++ b/src/meego/style/MenuItemStyle.qml
@@ -44,7 +44,7 @@ import "UIConstants.js" as UI
 Style {
     id: root
     // Font
-    property string fontFamily: __fontFamily()
+    property string fontFamily: UiConstants.DefaultFontFamily
     property int fontPixelSize: 26 // UI.FONT_DEFAULT_SIZE
     property int fontCapitalization: Font.MixedCase
     property int fontWeight: Font.Bold

--- a/src/meego/style/QueryDialogStyle.qml
+++ b/src/meego/style/QueryDialogStyle.qml
@@ -42,7 +42,7 @@ import QtQuick 1.1
 import "UIConstants.js" as UI
 
 DialogStyle {
-    property string titleFontFamily: __fontFamily()
+    property string titleFontFamily: UiConstants.DefaultFontFamily
     property int titleFontPixelSize: UI.FONT_XLARGE
     property int titleFontCapitalization: Font.MixedCase
     property bool titleFontBold: true
@@ -62,7 +62,7 @@ DialogStyle {
     rightMargin: 33
     titleElideMode: Text.ElideNone
 
-    property string messageFontFamily: __fontFamily()
+    property string messageFontFamily: UiConstants.DefaultFontFamily
     property int messageFontPixelSize: UI.FONT_DEFAULT
     property color messageTextColor: "#ffffff"
 }

--- a/src/meego/style/SelectionDialogStyle.qml
+++ b/src/meego/style/SelectionDialogStyle.qml
@@ -89,7 +89,7 @@ DialogStyle {
 
     Text {
         id: titleText
-        font.family: __fontFamily()
+        font.family: UiConstants.DefaultFontFamily
         font.pixelSize: UI.FONT_XLARGE
         font.capitalization: Font.MixedCase
         font.bold: false
@@ -97,7 +97,7 @@ DialogStyle {
 
     Text {
         id: itemText
-        font.family: __fontFamily()
+        font.family: UiConstants.DefaultFontFamily
         font.pixelSize: UI.FONT_DEFAULT_SIZE
         font.capitalization: Font.MixedCase
         font.bold: true

--- a/src/meego/style/SliderStyle.qml
+++ b/src/meego/style/SliderStyle.qml
@@ -43,7 +43,7 @@ import "UIConstants.js" as UI
 
 Style {
     // Font
-    property string fontFamily: __fontFamily()
+    property string fontFamily: UiConstants.DefaultFontFamily
     property int fontPixelSize: UI.FONT_DEFAULT_SIZE
 
     // Color

--- a/src/meego/style/Style.qml
+++ b/src/meego/style/Style.qml
@@ -52,24 +52,4 @@ QtObject {
     // which isn't allowed by QtObject; this fix makes this possible
     default property alias children: styleClass.__defaultPropertyFix
     property list<QtObject> __defaultPropertyFix: [Item {}] //QML doesn't allow an empty list here
-
-    // styles must not set font families with referencing to UI.FONT_FAMILY
-    // as there may exist languages that request a different font;
-    // use __fontFamily() and __fontFamilyLight instead.
-    //
-    // app developers should use the UiConstants context property
-    function __fontFamily() {
-        if (locale && locale.language == "fa") {
-            return UI.FONT_FAMILY_FARSI;
-        }
-        return UI.FONT_FAMILY;
-    }
-
-    function __fontFamilyLight() {
-        if (locale && locale.language == "fa") {
-            return UI.FONT_FAMILY_LIGHT_FARSI;
-        }
-        return UI.FONT_FAMILY_LIGHT;
-    }
-
 }

--- a/src/meego/style/TextFieldStyle.qml
+++ b/src/meego/style/TextFieldStyle.qml
@@ -67,7 +67,7 @@ Item {
 
     Text {
         id: textProperties
-        font.family: (locale && locale.language == "fa") ? UI.FONT_FAMILY_LIGHT_FARSI : UI.FONT_FAMILY_LIGHT
+        font.family: UiConstants.DefaultFontFamilyLight
         font.pixelSize: UI.FONT_DEFAULT
         visible: false
     }


### PR DESCRIPTION
Replace them with C++ properties instead. This removes the (completely useless,
as locale cannot change) runtime binding evaluation all over the place, as well
as centralising the declaration of the font families.
