### PR TITLE
[qt-components] Expose a gconf key for framebuffer orientation in MDeclativeScreen

### DIFF
--- a/src/meego/mdeclarativescreen.h
+++ b/src/meego/mdeclarativescreen.h
@@ -138,6 +138,8 @@ public:
 
     Q_PROPERTY(bool isDisplayLandscape READ isDisplayLandscape NOTIFY physicalDisplayChanged FINAL)
 
+    Q_PROPERTY(int frameBufferRotation READ frameBufferRotation CONSTANT FINAL)
+
 public:
     static MDeclarativeScreen* instance();
     virtual ~MDeclarativeScreen();
@@ -172,6 +174,7 @@ public:
     bool isPortrait() const;
 
     bool isDisplayLandscape() const;
+    int frameBufferRotation() const;
 
     int dpi() const;
     DisplayCategory displayCategory() const;


### PR DESCRIPTION
This gconf key is also used by Sailfish Silica. Currently it's exposed
directly through a new property of MDeclarativeScreen, but it should
be used for more logic in later work.
