### PR TITLE
[localthemedaemonclient] PNGs are now preferred over SVGs

### DIFF
--- a/src/meego/themedaemon/mlocalthemedaemonclient.cpp
+++ b/src/meego/themedaemon/mlocalthemedaemonclient.cpp
@@ -132,10 +132,10 @@ MLocalThemeDaemonClient::MLocalThemeDaemonClient(const QString &testPath, QObjec
         if (themeRoots.at(i).endsWith(QDir::separator()))
             themeRoots[i].truncate(themeRoots.at(i).length() - 1);
 
-        buildHash(themeRoots.at(i) + QDir::separator() + "icons", QStringList() << "*.svg" << "*.png" << "*.jpg");
+        buildHash(themeRoots.at(i) + QDir::separator() + "icons", QStringList() << "*.png" << "*.svg" << "*.jpg");
     }
 
-    m_imageDirNodes.append(ImageDirNode("icons" , QStringList() << ".svg" << ".png" << ".jpg"));
+    m_imageDirNodes.append(ImageDirNode("icons" , QStringList() << ".png" << ".svg" << ".jpg"));
 
     qDebug() << "LocalThemeDaemonClient: Looking for assets in" << themeRoots;
 }


### PR DESCRIPTION
Theme inheritance does not work well with file types.
Earlier, if base has x.svg, it will be preferred over darko's x.png
This now has been changed, to prefer PNGs, but there's still that bug
not inheriting properly.
It is deemed safe to go this way for now, as rendering SVGs is slow
