### PR TITLE
[localthemedaemonclient] fix SVG prioritisation over inheritance

### DIFF
--- a/src/meego/themedaemon/mlocalthemedaemonclient.h
+++ b/src/meego/themedaemon/mlocalthemedaemonclient.h
@@ -78,8 +78,7 @@ public:
 
 private:
     /**
-     * Reads the image \a id from the available directories specified
-     * by m_imageDirNodes.
+     * Reads the image \a id from the built hash map
      */
     QImage readImage(const QString &id) const;
 
@@ -98,16 +97,7 @@ private:
         bool operator!=(const PixmapIdentifier &other) const;
     };
 
-    struct ImageDirNode
-    {
-        ImageDirNode(const QString &directory, const QStringList &suffixList);
-        QString directory;
-        QStringList suffixList;
-    };
-
     QHash<PixmapIdentifier, QPixmap> m_pixmapCache;
-    QList<ImageDirNode> m_imageDirNodes;
-
     QHash<QString, QString> m_filenameHash;
 
 #ifdef HAVE_MLITE


### PR DESCRIPTION
The whole model has been simplified: all file names (without path and extension)
are stored in one hash array across all inherited themes. Since extension is
ignored, the topmost theme to provide the graphic wins the race, no matter what
the file type is.
